### PR TITLE
additional installation step & conversion string url to html link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h2 align="center"><img src="https://emojis.slackmojis.com/emojis/images/1531849430/4246/blob-sunglasses.gif?1531849430" width="30"/> LARACT9 🐱‍💻, CUY UNIVERSE PROJECT <img src="https://media.giphy.com/media/12oufCB0MyZ1Go/giphy.gif" width="50"></h2>
 
 <p align="center"><em>Tech Entertainer <a href="https://youtube.com/deaafrizal">youtube.com/deaafrizal
-</a><img src="https://media.giphy.com/media/WUlplcMpOCEmTGBtBW/giphy.gif" width="30"> 
+</a><img src="https://media.giphy.com/media/WUlplcMpOCEmTGBtBW/giphy.gif" width="30">
 </em></p>
 
 <p align="center">
@@ -45,7 +45,7 @@ FORK atau coba-coba di clone project ini sekarang di lokal komputer kalian masin
 
 ### Setting Up Project
 
-Silahkan fork terlebih dahulu repository ini, kemudian clone repository yang udah kalian fork ya (Inget repository yang kalian fork, bukan repository ini). 
+Silahkan fork terlebih dahulu repository ini, kemudian clone repository yang udah kalian fork ya (Inget repository yang kalian fork, bukan repository ini).
 Bisa gunakan command berikut:
 ```bash
 git clone git@github.com:{username github kalian}/laract9.git
@@ -78,8 +78,12 @@ php artisan migrate
 Lanjut, generate aplikasi key untuk keamanan pada project laravel dengan menggunakan artisan command berikut:
 ```bash
 php artisan key:generate
-# atau 
+# atau
 php artisan key:generate --show
+```
+Untuk membuat file pada public storage dapat diakses lewat web gunakan Artisan command `storage:link`:
+```bash
+php artisan storage:link
 ```
 Install dependencies nodejs didalam folder `node_modules` menggunakan Npm atau Yarn:
 ```bash

--- a/resources/js/Components/Homepage/PostList.jsx
+++ b/resources/js/Components/Homepage/PostList.jsx
@@ -2,6 +2,7 @@ import RenderIfTrue from "@/helper/RenderIfTrue";
 import { formatTime } from "@/utils/jsHelper";
 import { Inertia } from "@inertiajs/inertia";
 import { Link } from "@inertiajs/inertia-react";
+import React from "react";
 import { useEffect, useState } from "react";
 import NotificationAlert from "../Default/NotificationAlert";
 
@@ -10,6 +11,8 @@ export default function PostList(props) {
   const [limiter, setLimiter] = useState(80);
   const [isValid, setIsValid] = useState(true);
   const [showNotif, setShowNotif] = useState(false);
+  const [descriptionParts, setDescriptionParts] = useState([]);
+  const [links, setLinks] = useState([]);
 
   useEffect(() => {
     let mount = true;
@@ -93,6 +96,22 @@ export default function PostList(props) {
     return Inertia.post("/post/saved-post/saved", data);
   };
 
+  const linkify = (text) => {
+    let replacedText, replacePattern, links;
+
+    replacePattern = /(\b(https?|ftp):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gim;
+    replacedText = text.replace(replacePattern, '#links#');
+    links = text.match(replacePattern);
+
+    setDescriptionParts(replacedText.split('#links#'));
+
+    if(links) setLinks(links);
+  }
+
+  useEffect(() => {
+    linkify(props.posts.description)
+  }, [props.posts.description])
+
   return (
     <div className="bg-base card mb-10 w-full shadow-lg dark:bg-slate-700 dark:text-white md:w-2/3 ">
       {props.posts.image &&
@@ -102,7 +121,22 @@ export default function PostList(props) {
         <NotificationAlert message={props.notif} />
       </RenderIfTrue>
       <div className="card-body p-6" data-aos="flip-left" data-aos-duration="500">
-        <p className="cursor-default break-normal break-words text-xl">{props.posts.description}</p>
+        <p className="cursor-default break-normal break-words text-xl">
+          {descriptionParts.map((part, index) => {
+            return (
+              <React.Fragment key={index}>
+                <span >{part}</span>
+                {(links && links[index] !== undefined) &&
+                  <span>
+                    <a
+                      className="underline"
+                      href={links[index]} target="_blank">{links[index]}</a>
+                  </span>
+                }
+              </React.Fragment>
+            )
+          })}
+        </p>
         <div className="flex flex-row border-b-4 border-b-secondary py-2 dark:border-b-slate-400">
           <div className="flex basis-1/2 items-end justify-start">
             <div className="cursor-default break-normal text-xs">posted {formatTime(props.posts.created_at)}</div>


### PR DESCRIPTION
patch: 
- readme.md : add step storage link, due some users don't know why images are broken.
- readme.md : remove trailing space.
- post description: conversion string URL to HTML link.

![image](https://user-images.githubusercontent.com/15923784/184779184-9f8b97f8-fb25-49a7-a976-80cc59d361e5.png)
biasanya bang dea suka repot copas2 URL waktu ngoreksi PR kawan2